### PR TITLE
Update post 1.13 tabcomplete handling

### DIFF
--- a/bukkit-post-1.13/src/main/resources/plugin.yml
+++ b/bukkit-post-1.13/src/main/resources/plugin.yml
@@ -6,4 +6,5 @@ api-version: "1.13"
 commands:
   tebex:
     aliases: [buycraft]
+    permission: buycraft.admin
     description: Main command for the Tebex plugin.


### PR DESCRIPTION
Resolves issue whereby non administrator users (without `buycraft.admin` permission) get the tabcomplete suggestions.